### PR TITLE
Use Devicons for coffescript

### DIFF
--- a/stylesheets/icons.less
+++ b/stylesheets/icons.less
@@ -1,8 +1,8 @@
 @import "fonts";
 
 .coffeescript-icon {
-  .fa;
-  content: '\f0f4';          // http://fortawesome.github.io/Font-Awesome/icon/coffee/
+  .di;
+  content: '\e651';          // http://vorillaz.github.io/devicons/#/singleicon/coffeescript
 }
 
 .grunt-icon {


### PR DESCRIPTION
I like like the coffescript icon from Devicons alot better then the one from Font-Awesome... hope you agree

Font-Awesome: 
![screenshot 2014-08-13 08 58 21](https://cloud.githubusercontent.com/assets/145288/3902075/5d72cdc0-22b7-11e4-83ef-a8f44537dcc2.png)

Devicons:
![screenshot 2014-08-13 08 57 58](https://cloud.githubusercontent.com/assets/145288/3902068/4ac44f32-22b7-11e4-9c69-21f43024ddd9.png)
