### PR TITLE
Add Haskell icons

### DIFF
--- a/styles/file-type-icons.less
+++ b/styles/file-type-icons.less
@@ -258,8 +258,8 @@
   }
 
   // Haskell files
-  [data-name$='.hs']:before,
-  [data-name$='.lhs']:before {
+  :not([data-name$='Spec.hs'])[data-name$='.hs']:before,
+  :not([data-name$='Spec.lhs'])[data-name$='.lhs']:before {
     .haskell-icon;
   }
 

--- a/styles/file-type-icons.less
+++ b/styles/file-type-icons.less
@@ -257,9 +257,17 @@
     .go-icon;
   }
 
+  // Haskell files
+  [data-name$='.hs']:before,
+  [data-name$='.lhs']:before {
+    .haskell-icon;
+  }
+
   // Specs
   [data-name$='spec.rb']:before,
   [data-name$='-spec.coffee']:before,
+  [data-name$='Spec.hs']:before,
+  [data-name$='Spec.lhs']:before,
   [data-name$='spec.exs']:before,
   [data-name$='test.exs']:before {
     .test-file-icon;

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -47,6 +47,7 @@
 .haskell-icon {
   .di;
   content: '\e677';          // http://vorillaz.github.io/devicons/#/singleicon/haskell
+  font-size: 155%;
 }
 
 .html-icon {

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -44,6 +44,11 @@
   content: '\e663';          // http://vorillaz.github.io/devicons/#/singleicon/gulp
 }
 
+.haskell-icon {
+  .di;
+  content: '\e677';          // http://vorillaz.github.io/devicons/#/singleicon/haskell
+}
+
 .html-icon {
   content: "\f0b6";          // http://octicons.github.com/icon/globe/
 }

--- a/styles/nuclide-file-type-icons.less
+++ b/styles/nuclide-file-type-icons.less
@@ -240,9 +240,17 @@
     .go-icon;
   }
 
+  // Haskell
+  span.icon[data-name$='.hs']:before,
+  span.icon[data-name$='.lhs']:before {
+    .haskell-icon;
+  }
+
   // Specs
   span.icon[data-name$='spec.rb']:before,
   span.icon[data-name$='-spec.coffee']:before,
+  span.icon[data-name$='Spec.hs']:before,
+  span.icon[data-name$='Spec.lhs']:before,
   span.icon[data-name$='spec.exs']:before,
   span.icon[data-name$='test.exs']:before {
     .test-file-icon;

--- a/styles/nuclide-file-type-icons.less
+++ b/styles/nuclide-file-type-icons.less
@@ -241,8 +241,8 @@
   }
 
   // Haskell
-  span.icon[data-name$='.hs']:before,
-  span.icon[data-name$='.lhs']:before {
+  span.icon:not([data-name$='Spec.hs'])[data-name$='.hs']:before,
+  span.icon:not([data-name$='Spec.lhs'])[data-name$='.lhs']:before {
     .haskell-icon;
   }
 


### PR DESCRIPTION
Add icons for Haskell (`.hs`) and Literate Haskell (`.lsh`) files, as well as the flask icon for Haskell Specs.

Works fine with Atom Dark and Atom Material themes, but using the One Dark theme the Haskell icons are offset a bit to the bottom:
![Icons appear offset using One Dark](https://cloud.githubusercontent.com/assets/12250169/14775996/73163e5a-0ac3-11e6-8915-6a5d0c1019b3.png)

Not sure how to fix that, I tried what was done with the `.go` and `.java` icons and explicitly set `top: 0px !important;` what fixed the issue on One Dark but moved the icons too high on Atom Dark and Atom Material.
