### PR TITLE
show gulp-icon for gulpfile.babel.js file

### DIFF
--- a/styles/file-type-icons.less
+++ b/styles/file-type-icons.less
@@ -242,7 +242,8 @@
   [data-name='Gulpfile.coffee']:before,
   [data-name='gulpfile.coffee']:before,
   [data-name='Gulpfile.js']:before,
-  [data-name='gulpfile.js']:before {
+  [data-name='gulpfile.js']:before,
+  [data-name='gulpfile.babel.js']:before {
     .gulp-icon;
   }
 

--- a/styles/nuclide-file-type-icons.less
+++ b/styles/nuclide-file-type-icons.less
@@ -225,6 +225,7 @@
   span.icon[data-name='Gulpfile.coffee']:before,
   span.icon[data-name='gulpfile.coffee']:before,
   span.icon[data-name='Gulpfile.js']:before,
+  span.icon[data-name='gulpfile.babel.js']:before, 
   span.icon[data-name='gulpfile.js']:before {
     .gulp-icon;
   }


### PR DESCRIPTION
Many gulpfiles, e.g. the one googles popular [web starter kit](https://github.com/google/web-starter-kit) is using, are actually named 'gulpfile.babel.js', so they may be written in full ES6.

Therefore I suggest adding this file name pattern for the gulp icon.